### PR TITLE
Fixes bug handling percentage localization on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-
+#### Fixed
+- Fixes handling of % character on iOS localization
 
 ## [2.0.0](https://github.com/hole19/bisu/releases/tag/v2.0.0)
 Released on 2023/12/07

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bisu (1.10.2)
+    bisu (2.0.0)
       colorize
       rubyzip (>= 2.0.0)
       safe_yaml (>= 1.0.0)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Setup your configuration file
     file_name: <ONE-SKY-FILE-NAME>
   ```
 
-Create translation templates
+Create translatable files templates
 -----
 
 Create a \*.translatable version for your platform specific localization files:
@@ -114,19 +114,10 @@ Create a \*.translatable version for your platform specific localization files:
 *example: Localizable.strings.translatable*
 
   ```
-  // $specialKComment1$
-  // $specialKComment2$
-
-  // Locale: $specialKLocale$; Language used: $specialKLanguage$
-
-  /***********
-  *  General
-  ************/
-
-  "klGeneral_Delete" = "$kDelete$";
-  "klGeneral_Cancel" = "$kCancel$";
-  "klGeneral_Close"  = "$kClose$";
-  "klRequestName"    = "$kRequestName{user_name: %@}$";
+  "delete" = "$general.delete$";
+  "cancel" = "$general.cancel$";
+  "close" = "$general.close$";
+  "requestName" = "$request.name{user_name: %@}$";
   ```
 
 ##### Android
@@ -135,15 +126,11 @@ Create a \*.translatable version for your platform specific localization files:
   ```
   <?xml version="1.0" encoding="utf-8"?>
 
-  <!-- $specialKComment1$ -->
-  <!-- $specialKComment2$ -->
-  <!-- Locale: $specialKLocale$; Language used: $specialKLanguage$ -->
-
   <resources>
-      <string name="delete">$kDelete$</string>
-      <string name="cancel">$kCancel$</string>
-      <string name="close">$kClose$</string>
-      <string name="request_name">$kRequestName{user_name: %s}$</string>
+      <string name="delete">$general.delete$</string>
+      <string name="cancel">$general.cancel$</string>
+      <string name="close">$general.close$</string>
+      <string name="request_name">$request.name{user_name: %s}$</string>
   </resources>
   ```
 
@@ -153,9 +140,27 @@ Create a \*.translatable version for your platform specific localization files:
   ```
   $specialKLocale$:
     resources:
-      delete: $kDelete$
-      cancel: $kCancel$
-      close: $kClose$
+      delete: $general.delete$
+      cancel: $general.cancel$
+      close: $general.close$
     messages:
-      request_name: $kRequestName$
+      request_name: $request.name$
   ```
+
+### Translatable options
+
+#### Parameters
+
+Given a key with params such as "Missing ${attribute} value"
+- `$some-key-with-params{param: %s}$`: `Missing $s value`
+- `$some-key-with-params//ignore-params$`: `Missing ${attribute} value`
+
+#### Locale (useful for Rails localization files)
+
+- `$specialKLocale$`: the respective locale of this file
+- `$specialKLanguage$`: the respective language on the translation platform
+
+#### Special comments
+
+- `$specialKComment1$`: `This file was automatically generated based on a translation template.`
+- `$specialKComment2$`: `Remember to CHANGE THE TEMPLATE and not this file!`

--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ Given a key with params such as "Missing ${attribute} value"
 - `$some-key-with-params{param: %s}$`: `Missing $s value`
 - `$some-key-with-params//ignore-params$`: `Missing ${attribute} value`
 
+#### Formated strings (special characters)
+
+##### "%" character (iOS only)
+
+When is should be localized as given such as "Perfect: 100 (%)"
+- `$some-key-with-percentage$`: `Perfect: 100%`
+
+When it should be localized as a formated string such as "Perfect: %{percentage} (%)"
+- `$some-key-with-percentage{percentage: %d}//formatted-string$`: `Perfect: %d (%%)` (note the double `%`)
+
 #### Locale (useful for Rails localization files)
 
 - `$specialKLocale$`: the respective locale of this file

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Setup your configuration file
     file_name: <ONE-SKY-FILE-NAME>
   ```
 
-Create translatable files templates
+Create translatable file templates
 -----
 
 Create a \*.translatable version for your platform specific localization files:
@@ -159,7 +159,7 @@ Given a key with params such as "Missing ${attribute} value"
 
 ##### "%" character (iOS only)
 
-When is should be localized as given such as "Perfect: 100 (%)"
+When it should be localized as given such as "Perfect: 100 (%)"
 - `$some-key-with-percentage$`: `Perfect: 100%`
 
 When it should be localized as a formated string such as "Perfect: %{percentage} (%)"

--- a/spec/lib/bisu/localizer_spec.rb
+++ b/spec/lib/bisu/localizer_spec.rb
@@ -66,10 +66,11 @@ describe Bisu::Localizer do
 
     it { translates("$kDoubleQuoted$", to: expected[:double_quoted]) }
     it { translates("$kSingleQuoted$", to: expected[:single_quoted]) }
-    it { translates("$kEllipsis$",     to: expected[:ellipsis]) }
-    it { translates("$kAmpersand$",    to: expected[:ampersand]) }
-    it { translates("$kAtSign$",       to: expected[:at_sign]) }
-    it { translates("$kPercentage$",   to: expected[:percentage]) }
+    it { translates("$kEllipsis$", to: expected[:ellipsis]) }
+    it { translates("$kAmpersand$", to: expected[:ampersand]) }
+    it { translates("$kAtSign$", to: expected[:at_sign]) }
+    it { translates("$kPercentage$", to: expected[:percentage]) }
+    it { translates("$kPercentage//formatted-string$", to: expected[:percentage_formatted]) }
 
     # error handling
 
@@ -130,10 +131,11 @@ describe Bisu::Localizer do
   let(:type_dependent_defaults) { {
     double_quoted: keys[language]["kDoubleQuoted"],
     single_quoted: keys[language]["kSingleQuoted"],
-    ellipsis:      keys[language]["kEllipsis"],
-    ampersand:     keys[language]["kAmpersand"],
-    at_sign:       keys[language]["kAtSign"],
-    percentage:    keys[language]["kPercentage"]
+    ellipsis: keys[language]["kEllipsis"],
+    ampersand: keys[language]["kAmpersand"],
+    at_sign: keys[language]["kAtSign"],
+    percentage: keys[language]["kPercentage"],
+    percentage_formatted: keys[language]["kPercentage"],
   } }
 
   describe "of type iOS" do
@@ -141,7 +143,8 @@ describe Bisu::Localizer do
 
     let(:expected) { type_dependent_defaults.merge(
       double_quoted: "Não sabes nada \\\"João das Neves\\\"",
-      percentage: "Sabes 0%% João das Neves."
+      percentage: "Sabes 0% João das Neves.",
+      percentage_formatted: "Sabes 0%% João das Neves.",
     ) }
 
     it_behaves_like "a localizer"
@@ -182,7 +185,8 @@ describe Bisu::Localizer do
       ellipsis: "Não sabes nada João das Neves…",
       ampersand: "Não sabes nada João das Neves &amp; Pícaros",
       at_sign: "\\@johnsnow sabes alguma coisa?",
-      percentage: "Sabes 0\\%% João das Neves."
+      percentage: "Sabes 0\\%% João das Neves.",
+      percentage_formatted: "Sabes 0\\%% João das Neves.",
     ) }
 
     it_behaves_like "a localizer"


### PR DESCRIPTION
On iOS, the percentage sign is being "escaped". For instance, a string with "Completed 100%" would become "Completed 100%%". This is only necessary when using formatted strings (similar to C language string formatting).

So, it still makes for "Completed ${value}%" to become "Completed %d%%" since it's going to be used as a format string. But a string without params such as "Completed 100%" should stay the same.