### PR TITLE
Escape double quotes on Kotlin localization

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bisu (2.0.0)
+    bisu (2.1.0)
       colorize
       rubyzip (>= 2.0.0)
       safe_yaml (>= 1.0.0)

--- a/lib/bisu/localizer.rb
+++ b/lib/bisu/localizer.rb
@@ -82,6 +82,7 @@ module Bisu
 
       if @type.eql?(:android)
         text = text.gsub(/[']/, "\\\\\\\\'")
+        text = text.gsub(/\"/, "\\\\\"")
         text = text.gsub("...", "…")
         text = text.gsub("& ", "&amp; ")
         text = text.gsub("@", "\\\\@")

--- a/spec/lib/bisu/localizer_spec.rb
+++ b/spec/lib/bisu/localizer_spec.rb
@@ -182,6 +182,7 @@ describe Bisu::Localizer do
 
     let(:expected) { type_dependent_defaults.merge(
       single_quoted: "Não sabes nada \\'João das Neves\\'",
+      double_quoted: "Não sabes nada \\\"João das Neves\\\"",
       ellipsis: "Não sabes nada João das Neves…",
       ampersand: "Não sabes nada João das Neves &amp; Pícaros",
       at_sign: "\\@johnsnow sabes alguma coisa?",


### PR DESCRIPTION
Apparently, in Kotlin, when you don't escape double quotes, they disappear.
This PR adds escaping to double quotes for Kotlin/Android