### PR TITLE
Escape double quotes in ruby

### DIFF
--- a/lib/bisu/localizer.rb
+++ b/lib/bisu/localizer.rb
@@ -79,17 +79,16 @@ module Bisu
 
     def process(text, is_formatted_string)
       text = text.gsub("\n", "\\n")
+      text = text.gsub(/\"/, "\\\\\"")
 
-      if @type.eql?(:android)
+      case @type
+      when :android
         text = text.gsub(/[']/, "\\\\\\\\'")
-        text = text.gsub(/\"/, "\\\\\"")
         text = text.gsub("...", "…")
         text = text.gsub("&", "&amp;")
         text = text.gsub("@", "\\\\@")
         text = text.gsub(/%(?!{)/, "\\\\%%")
-
-      elsif @type.eql?(:ios)
-        text = text.gsub(/\"/, "\\\\\"")
+      when :ios
         text = text.gsub(/%(?!{)/, "%%") if is_formatted_string
       end
 

--- a/spec/lib/bisu/localizer_spec.rb
+++ b/spec/lib/bisu/localizer_spec.rb
@@ -196,7 +196,9 @@ describe Bisu::Localizer do
   describe "of type Ruby on Rails" do
     let(:type) { :ror }
 
-    let(:expected) { type_dependent_defaults }
+    let(:expected) { type_dependent_defaults.merge(
+      double_quoted: "Não sabes nada \\\"João das Neves\\\"",
+    ) }
 
     it_behaves_like "a localizer"
   end


### PR DESCRIPTION
Escape double quotes for all supported languages, including Ruby